### PR TITLE
Revert "Enable legacy MMAP"

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -48,9 +48,6 @@ TARGET_PROVIDES_LIBLIGHT := true
 # Include an expanded selection of fonts
 EXTENDED_FONT_FOOTPRINT := true
 
-# Legacy MMAP for pre-lollipop blobs
-BOARD_USES_LEGACY_MMAP := true
-
 # Shader cache config options
 # Maximum size of the  GLES Shaders that can be cached for reuse.
 # Increase the size if shaders of size greater than 12KB are used.


### PR DESCRIPTION
We needed this for rmt_storage blob, but for serrano we now
uses the blob from deb, thus this is not needed.

Other msm8930 devices should be able to use the same blob,
but if they want to stay on the old one, they can set this
flag in their device config.

This reverts commit 1ceb258fe0e5311cdf56684809572c4bdeff3c2d.

Change-Id: I7e7633f527d7053af841813d4ff60fda359a925d